### PR TITLE
feat: Make TOC sticky on scroll

### DIFF
--- a/src/app/layout-globals.css
+++ b/src/app/layout-globals.css
@@ -59,7 +59,6 @@ main {
 .content-container {
   width: 100%;
   max-width: 100vw;
-  overflow-x: hidden;
   background-color: var(--background);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,7 +73,7 @@ export default async function RootLayout({
   return (
     <html
       lang="ja"
-      className="overflow-x-hidden h-full"
+      className="h-full"
       suppressHydrationWarning
     >
       <head>
@@ -91,7 +91,7 @@ export default async function RootLayout({
           zen_maru_gothic.className,
           exo_2.variable,
           monoFont.variable,
-          "flex flex-col w-full min-h-screen overflow-x-hidden"
+          "flex flex-col w-full min-h-screen"
         )}
       >
         <ThemeProvider>

--- a/src/styles/markdown.module.scss
+++ b/src/styles/markdown.module.scss
@@ -320,27 +320,17 @@
 
 // CSS Modules用にローカルクラスを定義
 .tocWrapper {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  display: flex;
   gap: 32px;
   width: 100%;
   position: relative;
-
-  @media (min-width: 1080px) {
-    grid-template-columns: minmax(0, 1fr) 300px;
-  }
+  align-items: flex-start;
 }
 
 .tocMain {
-  width: 100%;
-  max-width: 100%;
-  margin: 0;
   flex: 1 1 0%;
-
-  @media (min-width: 1080px) {
-    grid-column-start: 1;
-    max-width: 960px;
-  }
+  min-width: 0;
+  max-width: 100%;
 }
 
 .tocSide {
@@ -348,15 +338,13 @@
 
   @media (min-width: 1080px) {
     display: block;
-    grid-column-start: 2;
     width: 300px;
     position: sticky;
-    top: calc(var(--header-height, 80px) + 16px);
-    align-self: flex-start;
-    max-height: calc(100vh - var(--header-height, 80px) - 32px);
+    top: calc(var(--header-height, 80px) + 1.5rem);
+    align-self: start;
+    max-height: calc(100vh - var(--header-height, 80px) - 3rem);
     overflow-y: auto;
     z-index: 10;
-    height: fit-content;
   }
 }
 


### PR DESCRIPTION
- Adjusting the `top` and `max-height` values for the sticky TOC to ensure it is positioned correctly relative to the header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the layout of the table of contents to use a flexbox-based design for improved alignment and spacing.
  - Adjusted sidebar appearance and positioning for better consistency on large screens.
  - Modified content container and layout styles to allow horizontal scrolling where necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->