### PR TITLE
fix: ページネーションで1ページ目と最後のページが重複するバグを修正

### DIFF
--- a/src/components/ui/Pagination.stories.tsx
+++ b/src/components/ui/Pagination.stories.tsx
@@ -4,10 +4,78 @@ import { Pagination } from "./Pagination";
 export default {
   title: "Components/Ui/Pagination",
   component: Pagination,
+  argTypes: {
+    currentPage: {
+      control: { type: "number", min: 1 },
+    },
+    totalPages: {
+      control: { type: "number", min: 1 },
+    },
+  },
 } satisfies Meta<typeof Pagination>;
 
 type Story = StoryObj<typeof Pagination>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    currentPage: 1,
+    totalPages: 10,
+    basePath: "blog",
+  },
+};
+
+export const FewPages: Story = {
+  args: {
+    currentPage: 2,
+    totalPages: 3,
+    basePath: "blog",
+  },
+};
+
+export const CurrentPageIsTwo: Story = {
+  args: {
+    currentPage: 2,
+    totalPages: 10,
+    basePath: "blog",
+  },
+};
+
+export const CurrentPageIsThree: Story = {
+  args: {
+    currentPage: 3,
+    totalPages: 10,
+    basePath: "blog",
+  },
+};
+
+export const MiddlePage: Story = {
+  args: {
+    currentPage: 5,
+    totalPages: 10,
+    basePath: "blog",
+  },
+};
+
+export const NearLastPage: Story = {
+  args: {
+    currentPage: 8,
+    totalPages: 10,
+    basePath: "blog",
+  },
+};
+
+export const LastPage: Story = {
+  args: {
+    currentPage: 10,
+    totalPages: 10,
+    basePath: "blog",
+  },
+};
+
+export const SecondToLastPage: Story = {
+  args: {
+    currentPage: 9,
+    totalPages: 10,
+    basePath: "blog",
+  },
 };

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -59,19 +59,46 @@ export const Pagination = ({
       {/* 前へボタン */}
       {renderNavigationButton(currentPage - 1, "前へ", currentPage > 1)}
 
-      {/* 最初のページ (1ページ目) */}
-      {currentPage > 2 && renderPageButton(1)}
-
-      {/* 現在のページ周辺のページ */}
-      {Array.from({ length: totalPages }, (_, i) => i + 1)
-        .filter((page) => {
-          if (totalPages <= 5) return true;
-          return Math.abs(page - currentPage) <= 1;
-        })
-        .map((page) => renderPageButton(page, page === currentPage))}
-
-      {/* 最後のページ */}
-      {currentPage < totalPages - 1 && renderPageButton(totalPages)}
+      {/* ページ番号の表示ロジック */}
+      {(() => {
+        const pages: (number | string)[] = [];
+        
+        // 総ページ数が5以下の場合はすべて表示
+        if (totalPages <= 5) {
+          for (let i = 1; i <= totalPages; i++) {
+            pages.push(i);
+          }
+        } else {
+          // 常に1ページ目を表示
+          pages.push(1);
+          
+          // 現在のページが1-3の場合
+          if (currentPage <= 3) {
+            pages.push(2, 3, 4);
+            pages.push("...");
+            pages.push(totalPages);
+          }
+          // 現在のページが最後から3ページ以内の場合
+          else if (currentPage >= totalPages - 2) {
+            pages.push("...");
+            pages.push(totalPages - 3, totalPages - 2, totalPages - 1, totalPages);
+          }
+          // それ以外（中間のページ）の場合
+          else {
+            pages.push("...");
+            pages.push(currentPage - 1, currentPage, currentPage + 1);
+            pages.push("...");
+            pages.push(totalPages);
+          }
+        }
+        
+        return pages.map((page, index) => {
+          if (typeof page === "string") {
+            return <span key={`ellipsis-${index}`} className="px-2">{page}</span>;
+          }
+          return renderPageButton(page, page === currentPage);
+        });
+      })()}
 
       {/* 次へボタン */}
       {renderNavigationButton(


### PR DESCRIPTION
## Summary
- ページネーションコンポーネントで、特定の条件下でページ番号が重複して表示される問題を修正しました
- ページ番号の表示ロジックを明確に分離し、重複を防ぐ新しいアルゴリズムを実装
- Storybookにエッジケースを含む複数のテストケースを追加

## Test plan
- [ ] Storybookで各種パターンを確認
  - [ ] `FewPages`: 総ページ数が3の場合
  - [ ] `CurrentPageIsTwo`: 現在のページが2の場合（以前は1が重複）
  - [ ] `CurrentPageIsThree`: 現在のページが3の場合
  - [ ] `MiddlePage`: 中間のページ（5/10ページ）
  - [ ] `NearLastPage`: 最後に近いページ（8/10ページ）
  - [ ] `SecondToLastPage`: 最後から2番目のページ（以前は最後が重複）
  - [ ] `LastPage`: 最後のページ
- [ ] 実際のブログページでページネーションが正しく動作することを確認