### PR TITLE
Fix series article list page display bug

### DIFF
--- a/src/app/series/[series]/page.tsx
+++ b/src/app/series/[series]/page.tsx
@@ -144,7 +144,7 @@ export default async function SeriesDetailPage({ params }: Props) {
 
       <div className="mt-8">
         <Link
-          href="/series"
+          href="/series/"
           className="hover:underline transition-colors duration-200"
           style={{ color: "var(--accent-primary)" }}
         >

--- a/src/app/series/[series]/page.tsx
+++ b/src/app/series/[series]/page.tsx
@@ -15,24 +15,22 @@ type Props = {
 export async function generateStaticParams() {
   const allSeries = await getAllSeries();
   return Object.keys(allSeries).map((seriesName) => ({
-    series: encodeURIComponent(seriesName),
+    series: seriesName,
   }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { series } = await params;
-  const seriesName = decodeURIComponent(series);
-  
+
   return {
-    title: `${seriesName} シリーズ | ${config.metadata.title}`,
-    description: `${seriesName} シリーズの記事一覧`,
+    title: `${series} シリーズ | ${config.metadata.title}`,
+    description: `${series} シリーズの記事一覧`,
   };
 }
 
 export default async function SeriesDetailPage({ params }: Props) {
   const { series } = await params;
-  const seriesName = decodeURIComponent(series);
-  const seriesPosts = await getSeriesPosts(seriesName);
+  const seriesPosts = await getSeriesPosts(series);
 
   if (seriesPosts.length === 0) {
     notFound();
@@ -42,17 +40,17 @@ export default async function SeriesDetailPage({ params }: Props) {
     <main className="flex flex-col w-full max-w-4xl mx-auto px-4 pb-16">
       <div className="mb-8">
         <div className="flex items-center gap-2 mb-4">
-          <Icon 
+          <Icon
             icon="lucide:book-open"
             width={24}
             height={24}
-            style={{ color: "var(--accent-primary)" }} 
+            style={{ color: "var(--accent-primary)" }}
           />
-          <h1 
+          <h1
             className="text-3xl font-bold"
             style={{ color: "var(--foreground)" }}
           >
-            {seriesName}
+            {series}
           </h1>
         </div>
         

--- a/src/components/Pages/SeriesPageClient.tsx
+++ b/src/components/Pages/SeriesPageClient.tsx
@@ -4,9 +4,10 @@ import Link from "next/link";
 import { Icon } from "@iconify/react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { useTranslation } from "@/libs/i18n/client";
+import type { SeriesInfo } from "@/libs/contents/series";
 
 type SeriesPageClientProps = {
-  seriesEntries: [string, any][];
+  seriesEntries: [string, SeriesInfo][];
 };
 
 export function SeriesPageClient({ seriesEntries }: SeriesPageClientProps) {
@@ -50,7 +51,7 @@ export function SeriesPageClient({ seriesEntries }: SeriesPageClientProps) {
                 <div className="flex-1">
                   <h2 className="text-xl font-semibold mb-2">
                     <Link
-                      href={`/series/${encodeURIComponent(seriesName)}`}
+                      href={`/series/${encodeURIComponent(seriesName)}/`}
                       className="hover:underline transition-colors duration-200"
                       style={{
                         color: "var(--foreground)",
@@ -79,7 +80,7 @@ export function SeriesPageClient({ seriesEntries }: SeriesPageClientProps) {
                   </div>
 
                   <div className="space-y-2">
-                    {seriesInfo.posts.slice(0, 3).map((post: any, index: number) => (
+                    {seriesInfo.posts.slice(0, 3).map((post, index) => (
                       <div key={post.slug} className="text-sm">
                         <Link
                           href={`/blog/post/${post.slug}`}
@@ -101,7 +102,7 @@ export function SeriesPageClient({ seriesEntries }: SeriesPageClientProps) {
 
                   <div className="mt-4">
                     <Link
-                      href={`/series/${encodeURIComponent(seriesName)}`}
+                      href={`/series/${encodeURIComponent(seriesName)}/`}
                       className="text-sm hover:underline transition-colors duration-200"
                       style={{ color: "var(--accent-primary)" }}
                     >

--- a/src/components/SeriesNavigation.tsx
+++ b/src/components/SeriesNavigation.tsx
@@ -84,7 +84,7 @@ export function SeriesNavigation({
 
       <div className="mt-4">
         <Link
-          href={`/series/${encodeURIComponent(seriesName)}`}
+          href={`/series/${encodeURIComponent(seriesName)}/`}
           className="text-sm hover:underline transition-colors duration-200"
           style={{ color: "var(--accent-primary)" }}
         >


### PR DESCRIPTION
- SeriesPageClient で any 型を SeriesInfo 型に変更して型安全性を向上
- Next.js の trailingSlash 設定に合わせて、すべてのシリーズページへのリンクに trailing slash を追加
- SeriesNavigation、SeriesPageClient、series/[series]/page.tsx の3ファイルを修正

この修正により、シリーズページへのナビゲーションが正しく機能するようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in series components for more reliable behavior.
  * Standardized series URLs to consistently include trailing slashes for smoother navigation.

* **Bug Fixes**
  * Series page titles, headers and metadata now consistently display and use the raw series name to ensure correct page content and SEO.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->