### PR TITLE
CodeHike コンポーネントのダークモード対応

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,17 @@
   --header-scrolled-bg-light: rgba(255, 255, 255, 0.92);
   --input-bg-light: #ffffff;
 
+  /* CodeHikeコンポーネント用のライトテーマ変数 */
+  --codehike-callout-bg-light: #eff6ff;
+  --codehike-callout-border-light: #93c5fd;
+  --codehike-tooltip-bg-light: #ffffff;
+  --codehike-tooltip-border-light: #cbd5e1;
+  --codehike-tooltip-text-light: #1e293b;
+  --codehike-muted-text-light: #94a3b8;
+  --codehike-footnote-border-light: #94a3b8;
+  --codehike-diff-add-light: #3fb950;
+  --codehike-diff-remove-light: #f85149;
+
   /* Messageコンポーネント用のライトテーマ変数 */
   --info-bg-light: #f0f7ff;
   --info-border-light: #93c5fd;
@@ -73,6 +84,17 @@
   --header-scrolled-bg-dark: rgba(41, 50, 68, 0.92);
   --input-bg-dark: #293244;
 
+  /* CodeHikeコンポーネント用のダークテーマ変数 */
+  --codehike-callout-bg-dark: #1e3a5f;
+  --codehike-callout-border-dark: #3b82f6;
+  --codehike-tooltip-bg-dark: #2c3549;
+  --codehike-tooltip-border-dark: #475569;
+  --codehike-tooltip-text-dark: #e2e8f0;
+  --codehike-muted-text-dark: #cbd5e1;
+  --codehike-footnote-border-dark: #64748b;
+  --codehike-diff-add-dark: #3fb950;
+  --codehike-diff-remove-dark: #f85149;
+
   /* Messageコンポーネント用のダークテーマ変数 */
   --info-bg-dark: #172554;
   --info-border-dark: #3b82f6;
@@ -111,6 +133,17 @@
   --header-bg: var(--header-bg-light);
   --header-scrolled-bg: var(--header-scrolled-bg-light);
   --input-bg: var(--input-bg-light);
+
+  /* CodeHikeコンポーネントのデフォルト変数 */
+  --codehike-callout-bg: var(--codehike-callout-bg-light);
+  --codehike-callout-border: var(--codehike-callout-border-light);
+  --codehike-tooltip-bg: var(--codehike-tooltip-bg-light);
+  --codehike-tooltip-border: var(--codehike-tooltip-border-light);
+  --codehike-tooltip-text: var(--codehike-tooltip-text-light);
+  --codehike-muted-text: var(--codehike-muted-text-light);
+  --codehike-footnote-border: var(--codehike-footnote-border-light);
+  --codehike-diff-add: var(--codehike-diff-add-light);
+  --codehike-diff-remove: var(--codehike-diff-remove-light);
 
   /* Messageコンポーネントのデフォルト変数 */
   --info-bg: var(--info-bg-light);
@@ -164,6 +197,17 @@
     /* SVGフィルター用変数 */
     --svg-filter: invert(1);
 
+    /* CodeHike コンポーネント用ダークモード設定 */
+    --codehike-callout-bg: var(--codehike-callout-bg-dark);
+    --codehike-callout-border: var(--codehike-callout-border-dark);
+    --codehike-tooltip-bg: var(--codehike-tooltip-bg-dark);
+    --codehike-tooltip-border: var(--codehike-tooltip-border-dark);
+    --codehike-tooltip-text: var(--codehike-tooltip-text-dark);
+    --codehike-muted-text: var(--codehike-muted-text-dark);
+    --codehike-footnote-border: var(--codehike-footnote-border-dark);
+    --codehike-diff-add: var(--codehike-diff-add-dark);
+    --codehike-diff-remove: var(--codehike-diff-remove-dark);
+
     /* Message コンポーネント用ダークモード設定 */
     --info-bg: var(--info-bg-dark);
     --info-border: var(--info-border-dark);
@@ -212,6 +256,17 @@
 
   /* SVGフィルター用変数 */
   --svg-filter: invert(1);
+
+  /* CodeHike コンポーネント用ダークモード設定 */
+  --codehike-callout-bg: var(--codehike-callout-bg-dark);
+  --codehike-callout-border: var(--codehike-callout-border-dark);
+  --codehike-tooltip-bg: var(--codehike-tooltip-bg-dark);
+  --codehike-tooltip-border: var(--codehike-tooltip-border-dark);
+  --codehike-tooltip-text: var(--codehike-tooltip-text-dark);
+  --codehike-muted-text: var(--codehike-muted-text-dark);
+  --codehike-footnote-border: var(--codehike-footnote-border-dark);
+  --codehike-diff-add: var(--codehike-diff-add-dark);
+  --codehike-diff-remove: var(--codehike-diff-remove-dark);
 
   /* Message コンポーネント用ダークモード設定 */
   --info-bg: var(--info-bg-dark);
@@ -347,6 +402,17 @@
     --header-bg: var(--header-bg-dark);
     --header-scrolled-bg: var(--header-scrolled-bg-dark);
     --input-bg: var(--input-bg-dark);
+
+    /* CodeHike コンポーネント用ダークモード設定 */
+    --codehike-callout-bg: var(--codehike-callout-bg-dark);
+    --codehike-callout-border: var(--codehike-callout-border-dark);
+    --codehike-tooltip-bg: var(--codehike-tooltip-bg-dark);
+    --codehike-tooltip-border: var(--codehike-tooltip-border-dark);
+    --codehike-tooltip-text: var(--codehike-tooltip-text-dark);
+    --codehike-muted-text: var(--codehike-muted-text-dark);
+    --codehike-footnote-border: var(--codehike-footnote-border-dark);
+    --codehike-diff-add: var(--codehike-diff-add-dark);
+    --codehike-diff-remove: var(--codehike-diff-remove-dark);
 
     /* Message コンポーネント用ダークモード設定 */
     --info-bg: var(--info-bg-dark);
@@ -538,6 +604,17 @@ div[data-ch-line] * {
   --header-bg: var(--header-bg-dark);
   --header-scrolled-bg: var(--header-scrolled-bg-dark);
   --input-bg: var(--input-bg-dark);
+
+  /* CodeHikeコンポーネント用のダークテーマ変数 */
+  --codehike-callout-bg: var(--codehike-callout-bg-dark);
+  --codehike-callout-border: var(--codehike-callout-border-dark);
+  --codehike-tooltip-bg: var(--codehike-tooltip-bg-dark);
+  --codehike-tooltip-border: var(--codehike-tooltip-border-dark);
+  --codehike-tooltip-text: var(--codehike-tooltip-text-dark);
+  --codehike-muted-text: var(--codehike-muted-text-dark);
+  --codehike-footnote-border: var(--codehike-footnote-border-dark);
+  --codehike-diff-add: var(--codehike-diff-add-dark);
+  --codehike-diff-remove: var(--codehike-diff-remove-dark);
 
   /* Messageコンポーネント用のダークテーマ変数 */
   --info-bg: var(--info-bg-dark);

--- a/src/components/CodeHike/callout.tsx
+++ b/src/components/CodeHike/callout.tsx
@@ -18,12 +18,21 @@ export const callout: AnnotationHandler = {
       <>
         {children}
         <div
-          style={{ minWidth: `${column + 2}ch`, left: "3rem" }}
-          className="w-fit border border-zinc-400 bg-blue-50 border-current rounded px-2 relative -ml-[1ch] mt-1 whitespace-break-spaces"
+          style={{
+            minWidth: `${column + 2}ch`,
+            left: "3rem",
+            backgroundColor: "var(--codehike-callout-bg)",
+            borderColor: "var(--codehike-callout-border)"
+          }}
+          className="w-fit border rounded px-2 relative -ml-[1ch] mt-1 whitespace-break-spaces"
         >
           <div
-            style={{ left: `${column}ch` }}
-            className="absolute border-l border-t border-current border-zinc-400 w-2 h-2 rotate-45 -translate-y-1/2 -top-[1px] bg-blue-50"
+            style={{
+              left: `${column}ch`,
+              backgroundColor: "var(--codehike-callout-bg)",
+              borderColor: "var(--codehike-callout-border)"
+            }}
+            className="absolute border-l border-t w-2 h-2 rotate-45 -translate-y-1/2 -top-[1px]"
           />
           {annotation.query}
         </div>

--- a/src/components/CodeHike/diff.tsx
+++ b/src/components/CodeHike/diff.tsx
@@ -4,7 +4,10 @@ export const diff: AnnotationHandler = {
   name: "diff",
   onlyIfAnnotated: true,
   transform: (annotation: BlockAnnotation) => {
-    const color = annotation.query == "-" ? "#f85149" : "#3fb950";
+    const color =
+      annotation.query === "-"
+        ? "var(--codehike-diff-remove)"
+        : "var(--codehike-diff-add)";
     return [annotation, { ...annotation, name: "mark", query: color }];
   },
   Line: ({ annotation, ...props }) => (

--- a/src/components/CodeHike/footnote.tsx
+++ b/src/components/CodeHike/footnote.tsx
@@ -22,7 +22,8 @@ export function Number({ n }: { n: number }) {
     return (
         <span
             data-value={n}
-            className="after:content-[attr(data-value)] border border-slate-400 rounded-full inline-block h-4 w-4 text-center leading-4 text-sm font-mono self-center"
+            style={{ borderColor: "var(--codehike-footnote-border)" }}
+            className="after:content-[attr(data-value)] border rounded-full inline-block h-4 w-4 text-center leading-4 text-sm font-mono self-center"
         />
     )
 }

--- a/src/components/CodeHike/inline-code.tsx
+++ b/src/components/CodeHike/inline-code.tsx
@@ -26,7 +26,7 @@ export function InlineCode({ codeblock }: { codeblock: RawCode }) {
   }, [codeblock, theme]);
 
   if (loading || !highlighted) {
-    return <span className="text-gray-400">...</span>;
+    return <span style={{ color: "var(--codehike-muted-text)" }}>...</span>;
   }
 
   return <Inline code={highlighted} style={highlighted.style} />;

--- a/src/components/CodeHike/tooltip.tsx
+++ b/src/components/CodeHike/tooltip.tsx
@@ -5,23 +5,25 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { useTheme } from "next-themes";
 
 export const tooltip: AnnotationHandler = {
   name: "tooltip",
   Inline: ({ children, annotation }) => {
     const { query, data } = annotation;
-    const { resolvedTheme } = useTheme();
-    
+
     return (
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger className="underline decoration-dashed">
             {children}
           </TooltipTrigger>
-          <TooltipContent 
+          <TooltipContent
             align="start"
-            className={`${resolvedTheme === "dark" ? "border-gray-700 bg-gray-800 text-gray-200" : ""}`}
+            style={{
+              backgroundColor: "var(--codehike-tooltip-bg)",
+              borderColor: "var(--codehike-tooltip-border)",
+              color: "var(--codehike-tooltip-text)"
+            }}
           >
             {data?.children || query}
           </TooltipContent>


### PR DESCRIPTION
- globals.cssにCodeHike用のCSS変数を追加（ライト/ダークモード対応）
- callout.tsx: ハードコードされた色をCSS変数に置き換え
- tooltip.tsx: ハードコードされた色をCSS変数に置き換え
- inline-code.tsx: ハードコードされた色をCSS変数に置き換え
- footnote.tsx: ハードコードされた色をCSS変数に置き換え
- diff.tsx: ハードコードされた色をCSS変数に置き換え

これにより、すべてのCodeHikeコンポーネントがダークモードで適切に表示されるようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced theme support for code display components with CSS variable-driven styling.
  * Improved visual consistency across light and dark themes for callouts, tooltips, diffs, and inline code elements.
  * Theme switching now properly affects all code-related component colors and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->