### PR TITLE
Fix series page not displaying

### DIFF
--- a/src/app/series/[series]/page.tsx
+++ b/src/app/series/[series]/page.tsx
@@ -15,24 +15,22 @@ type Props = {
 export async function generateStaticParams() {
   const allSeries = await getAllSeries();
   return Object.keys(allSeries).map((seriesName) => ({
-    series: encodeURIComponent(seriesName),
+    series: seriesName,
   }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { series } = await params;
-  const seriesName = decodeURIComponent(series);
 
   return {
-    title: `${seriesName} シリーズ | ${config.metadata.title}`,
-    description: `${seriesName} シリーズの記事一覧`,
+    title: `${series} シリーズ | ${config.metadata.title}`,
+    description: `${series} シリーズの記事一覧`,
   };
 }
 
 export default async function SeriesDetailPage({ params }: Props) {
   const { series } = await params;
-  const seriesName = decodeURIComponent(series);
-  const seriesPosts = await getSeriesPosts(seriesName);
+  const seriesPosts = await getSeriesPosts(series);
 
   if (seriesPosts.length === 0) {
     notFound();
@@ -52,7 +50,7 @@ export default async function SeriesDetailPage({ params }: Props) {
             className="text-3xl font-bold"
             style={{ color: "var(--foreground)" }}
           >
-            {seriesName}
+            {series}
           </h1>
         </div>
         


### PR DESCRIPTION
generateStaticParams で encodeURIComponent を使用すると、
Next.js が out/series/Scala%20Cats%20%E5%9E%8B%E3%82%AF%E3%83%A9%E3%82%B9/ のようなエンコードされたフォルダ名を作成し、ファイルシステムや
Webサーバーで問題が発生していた。

修正内容:
- generateStaticParams: seriesName をそのまま返す（エンコードなし）
- generateMetadata: series を直接使用（decodeURIComponent 不要）
- SeriesDetailPage: series を直接使用（decodeURIComponent 不要）

これにより、Next.js は実際のシリーズ名でフォルダを作成し、
ブラウザからのエンコードされたURLリクエストを自動的にデコードして
正しいページとマッチングする。

リンク内の encodeURIComponent は href 属性として正しいため維持。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified series name handling throughout the application to use consistent raw values for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->