### PR TITLE
Fix tool component dark mode styling

### DIFF
--- a/src/components/ai-elements/tool.tsx
+++ b/src/components/ai-elements/tool.tsx
@@ -52,7 +52,13 @@ const getStatusBadge = (status: ToolUIPart["state"]) => {
   };
 
   return (
-    <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">
+    <Badge
+      className={cn(
+        "gap-1.5 rounded-full text-xs",
+        status === "output-available" && "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/30 dark:text-green-300 dark:border-green-800"
+      )}
+      variant={status === "output-available" ? "outline" : "secondary"}
+    >
       {icons[status]}
       {labels[status]}
     </Badge>


### PR DESCRIPTION
The Completed status badge in the Tool component now has proper dark mode support:
- Light mode: green background with darker green text
- Dark mode: dark green semi-transparent background with light green text
- Added appropriate borders for better visibility in both modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced status badge visual presentation with dynamic styling that adjusts appearance based on status type, providing distinct green styling for output-available status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->