### PR TITLE
Fix breadcrumb navigation on multiple pages

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -53,13 +53,13 @@ export default function BreadcrumbNav(props: BreadcrumbNavProps) {
               {segment.isLast ? (
                 <BreadcrumbItemLink asChild variant="active">
                   <span aria-current="page">
-                    {getDisplayTitle({ segment, data })}
+                    {getDisplayTitle({ segment, data, t })}
                   </span>
                 </BreadcrumbItemLink>
               ) : (
                 <BreadcrumbItemLink asChild>
                   <Link href={segment.path}>
-                    {getDisplayTitle({ segment, data })}
+                    {getDisplayTitle({ segment, data, t })}
                   </Link>
                 </BreadcrumbItemLink>
               )}

--- a/src/hooks/useBreadcrumbs.ts
+++ b/src/hooks/useBreadcrumbs.ts
@@ -74,21 +74,23 @@ interface BreadcrumbData {
   bookTitleMap: Record<string, string>;
 }
 
-// パスセグメントの表示名をマッピングするオブジェクト
-const segmentMappings: Record<string, string> = {
-  [ContentType.BLOG]: "ブログ",
-  [ContentType.SERIES]: "シリーズ",
-  [ContentType.KEYWORD]: "キーワード",
-  [ContentType.TOOL]: "ツール",
-  [ContentType.SEARCH]: "Search",
-  [ContentType.BOOKS]: "書籍",
-  programming: "プログラミング",
-  scala: "Scala",
-  cats: "Cats",
-  post: "記事",
-  page: "ページ",
-  "privacy-policy": "プライバシーポリシー",
-  contact: "お問い合わせ",
+// パスセグメントと翻訳キーのマッピング
+const segmentToTranslationKey: Record<string, string> = {
+  [ContentType.BLOG]: "blog",
+  [ContentType.SERIES]: "series",
+  [ContentType.KEYWORD]: "keywords",
+  [ContentType.TOOL]: "tools",
+  [ContentType.SEARCH]: "search",
+  [ContentType.BOOKS]: "books",
+  tags: "tags",
+  about: "about",
+  programming: "programming",
+  scala: "scala",
+  cats: "cats",
+  post: "post",
+  page: "page",
+  "privacy-policy": "privacyPolicy",
+  contact: "contact",
 };
 
 // 型ガード関数
@@ -230,15 +232,18 @@ function getPathSegments(segments: string[]): PathSegment[] {
 interface GetDisplayTitleProps {
   segment: PathSegment;
   data: BreadcrumbData;
+  t: (key: string) => string;
 }
 
 export function getDisplayTitle({
   segment,
   data,
+  t,
 }: GetDisplayTitleProps): string {
-  // 基本的なマッピングから取得
-  if (segment.name in segmentMappings) {
-    return segmentMappings[segment.name];
+  // 翻訳キーが存在する場合は翻訳を使用
+  const translationKey = segmentToTranslationKey[segment.name];
+  if (translationKey) {
+    return t(`breadcrumb.${translationKey}`);
   }
 
   // ブログのスラグからタイトルを取得

--- a/src/libs/i18n/locales/en/common.json
+++ b/src/libs/i18n/locales/en/common.json
@@ -17,7 +17,22 @@
     "poweredBy": "Powered by"
   },
   "breadcrumb": {
-    "home": "Home"
+    "home": "Home",
+    "blog": "Blog",
+    "series": "Series",
+    "keywords": "Keywords",
+    "tools": "Tools",
+    "search": "Search",
+    "books": "Books",
+    "tags": "Tags",
+    "about": "About",
+    "contact": "Contact",
+    "privacyPolicy": "Privacy Policy",
+    "programming": "Programming",
+    "scala": "Scala",
+    "cats": "Cats",
+    "post": "Post",
+    "page": "Page"
   },
   "language": {
     "ja": "Japanese",

--- a/src/libs/i18n/locales/ja/common.json
+++ b/src/libs/i18n/locales/ja/common.json
@@ -17,7 +17,22 @@
     "poweredBy": "Powered by"
   },
   "breadcrumb": {
-    "home": "ホーム"
+    "home": "ホーム",
+    "blog": "ブログ",
+    "series": "シリーズ",
+    "keywords": "キーワード",
+    "tools": "ツール",
+    "search": "検索",
+    "books": "書籍",
+    "tags": "タグ",
+    "about": "About",
+    "contact": "お問い合わせ",
+    "privacyPolicy": "プライバシーポリシー",
+    "programming": "プログラミング",
+    "scala": "Scala",
+    "cats": "Cats",
+    "post": "記事",
+    "page": "ページ"
   },
   "language": {
     "ja": "日本語",


### PR DESCRIPTION
…labels

- Add breadcrumb labels to translation files (ja/en) for all pages
- Add missing breadcrumb mappings for 'tags' and 'about' pages
- Replace hardcoded Japanese labels with i18n translation keys
- Update getDisplayTitle to accept translation function parameter
- Update Breadcrumb component to pass translation function

This ensures all pages have proper breadcrumb navigation with full internationalization support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation labels are now dynamically localized and translated in English and Japanese, automatically displaying in the user's selected language. Enhanced breadcrumb coverage for all major site sections including blog, tags, search, books, and contact pages, improving navigation clarity for multilingual users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->