### PR TITLE
Fix breadcrumb navigation 404 error

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -50,9 +50,9 @@ export default function BreadcrumbNav(props: BreadcrumbNavProps) {
         {pathSegments.map((segment) => (
           <React.Fragment key={segment.path}>
             <BreadcrumbItem>
-              {segment.isLast ? (
-                <BreadcrumbItemLink asChild variant="active">
-                  <span aria-current="page">
+              {segment.isLast || !segment.shouldLink ? (
+                <BreadcrumbItemLink asChild variant={segment.isLast ? "active" : "default"}>
+                  <span aria-current={segment.isLast ? "page" : undefined}>
                     {getDisplayTitle({ segment, data, t })}
                   </span>
                 </BreadcrumbItemLink>

--- a/src/hooks/useBreadcrumbs.ts
+++ b/src/hooks/useBreadcrumbs.ts
@@ -16,6 +16,7 @@ interface BasePathSegment {
   path: string;
   isLast: boolean;
   type: ContentType | string;
+  shouldLink: boolean; // リンクにすべきかどうか
 }
 
 // ブログのパスセグメント
@@ -92,6 +93,15 @@ const segmentToTranslationKey: Record<string, string> = {
   "privacy-policy": "privacyPolicy",
   contact: "contact",
 };
+
+// リンクにすべきでない中間セグメント名のセット
+// これらは単独ではページが存在しないため、リンク化しない
+const NON_LINKABLE_SEGMENTS = new Set(["post", "page"]);
+
+// セグメントがリンク可能かどうかを判定する関数
+function shouldBeLink(segmentName: string): boolean {
+  return !NON_LINKABLE_SEGMENTS.has(segmentName);
+}
 
 // 型ガード関数
 function isBlogSegment(segment: PathSegment): segment is BlogPathSegment {
@@ -208,6 +218,7 @@ function getPathSegments(segments: string[]): PathSegment[] {
       path: fullPath,
       isLast,
       type: decodedSegment,
+      shouldLink: shouldBeLink(decodedSegment),
     };
 
     // 最初のセグメントによってコンテンツタイプを判定


### PR DESCRIPTION
Add shouldLink property to PathSegment to determine if a segment should be linkable. Segments like 'post' and 'page' are intermediate paths that don't have their own pages, so they should not be rendered as links to avoid 404 errors.

Changes:
- Add shouldLink boolean to PathSegment type
- Define NON_LINKABLE_SEGMENTS set for intermediate segments
- Update Breadcrumb component to render non-linkable segments as text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced breadcrumb navigation to properly mark the current page as the active item
  * Refined breadcrumb behavior so certain page types (posts, pages) are no longer rendered as clickable links, improving navigation clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->