### PR TITLE
Add subtitle field to list display

### DIFF
--- a/src/app/blog/post/[slug]/page.tsx
+++ b/src/app/blog/post/[slug]/page.tsx
@@ -46,8 +46,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     `${config.metadata.url}/blog/post/${slug}/opengraph-image`;
   const url = `${config.metadata.url}/blog/post/${slug}/`;
 
+  const fullTitle = frontmatter.subtitle
+    ? `${frontmatter.title} - ${frontmatter.subtitle}`
+    : frontmatter.title;
+
   return {
-    title: `${frontmatter.title} | ${config.metadata.title}`,
+    title: `${fullTitle} | ${config.metadata.title}`,
     description:
       frontmatter.description ||
       `${frontmatter.title}に関する記事です。${config.metadata.description}`,
@@ -60,7 +64,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       canonical: url,
     },
     openGraph: {
-      title: frontmatter.title,
+      title: fullTitle,
       description:
         frontmatter.description || `${frontmatter.title}に関する記事です。`,
       url,
@@ -81,7 +85,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     twitter: {
       card: "summary_large_image",
-      title: frontmatter.title,
+      title: fullTitle,
       description:
         frontmatter.description || `${frontmatter.title}に関する記事です。`,
       creator: config.metadata.twitterHandle,
@@ -144,6 +148,7 @@ export default async function Page({ params }: Props) {
       />
       <Article
         title={frontmatter.title}
+        subtitle={frontmatter.subtitle}
         date={frontmatter.date}
         tags={frontmatter.tags}
         description={frontmatter.description}

--- a/src/app/series/[series]/page.tsx
+++ b/src/app/series/[series]/page.tsx
@@ -95,7 +95,7 @@ export default async function SeriesDetailPage({ params }: Props) {
                   <Link
                     href={`/blog/post/${post.slug}`}
                     className="hover:underline transition-colors duration-200"
-                    style={{ 
+                    style={{
                       color: "var(--foreground)",
                       textDecorationColor: "var(--accent-primary)"
                     }}
@@ -104,7 +104,16 @@ export default async function SeriesDetailPage({ params }: Props) {
                   </Link>
                 </h2>
 
-                <div 
+                {post.frontmatter.subtitle && (
+                  <div
+                    className="text-sm mb-2"
+                    style={{ color: "var(--muted)" }}
+                  >
+                    {post.frontmatter.subtitle}
+                  </div>
+                )}
+
+                <div
                   className="flex items-center gap-4 mb-3 text-sm"
                   style={{ color: "var(--muted)" }}
                 >

--- a/src/components/Article/Timeline.tsx
+++ b/src/components/Article/Timeline.tsx
@@ -17,7 +17,7 @@ const TimelineItem = ({
   showMonth = false,
   isLastInMonth = false, // デフォルトはfalse
 }: TimelineItemProps) => {
-  const { _path, title, date, tags } = post;
+  const { _path, title, subtitle, date, tags } = post;
   const year = format(date, "yyyy");
   const month = format(date, "M"); // 0埋めなしの月
   const day = format(date, "d"); // 0埋めなしの日
@@ -84,6 +84,14 @@ const TimelineItem = ({
         >
           {title}
         </Link>
+        {subtitle && (
+          <div
+            className="text-sm mb-2"
+            style={{ color: "var(--muted)" }}
+          >
+            {subtitle}
+          </div>
+        )}
         <div className="flex flex-wrap mt-2 gap-2 text-xs">
           {tags.map((tag) => (
             <Tag

--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -13,6 +13,7 @@ import { createBlogPostingJsonLd } from "@/libs/jsonld";
 
 export type ArticleProps = {
   title: string;
+  subtitle?: string;
   date: string | Date;
   tags: string[];
   children: ReactNode;
@@ -28,6 +29,7 @@ export type ArticleProps = {
 
 export function Article({
   title,
+  subtitle,
   date,
   tags,
   children,
@@ -71,6 +73,15 @@ export function Article({
           <h1 className="mb-8 text-center" data-pagefind-meta="title">
             {title}
           </h1>
+
+          {subtitle && (
+            <div
+              className="text-xl mb-6 text-center"
+              style={{ color: "var(--muted)" }}
+            >
+              {subtitle}
+            </div>
+          )}
 
           <div className="flex mt-2 mb-2 justify-center items-center">
             <span className="i-ic-outline-sync mr-0.5" />

--- a/src/components/SeriesNavigation.tsx
+++ b/src/components/SeriesNavigation.tsx
@@ -54,10 +54,10 @@ export function SeriesNavigation({
             style={{ color: "var(--accent-primary)" }}
           >
             <Icon icon="lucide:chevron-left" width={16} height={16} style={{ color: "currentColor" }} />
-            <span>前の記事: {previous.frontmatter.title}</span>
+            <span>前の記事: {previous.frontmatter.subtitle || previous.frontmatter.title}</span>
           </Link>
         ) : (
-          <div 
+          <div
             className="text-sm"
             style={{ color: "var(--muted)" }}
           >
@@ -71,11 +71,11 @@ export function SeriesNavigation({
             className="flex items-center gap-2 text-sm hover:underline transition-colors duration-200"
             style={{ color: "var(--accent-primary)" }}
           >
-            <span>次の記事: {next.frontmatter.title}</span>
+            <span>次の記事: {next.frontmatter.subtitle || next.frontmatter.title}</span>
             <Icon icon="lucide:chevron-right" width={16} height={16} style={{ color: "currentColor" }} />
           </Link>
         ) : (
-          <div 
+          <div
             className="text-sm"
             style={{ color: "var(--muted)" }}
           >

--- a/src/libs/contents/schema.ts
+++ b/src/libs/contents/schema.ts
@@ -11,6 +11,7 @@ export const baseFrontmatterSchema = z.object({
 
 // ブログ用のフロントマタースキーマ（基本 + 追加フィールド）
 export const blogFrontmatterSchema = baseFrontmatterSchema.extend({
+  subtitle: z.string().optional(), // サブタイトル
   description: z.string().optional(),
   author: z.string().optional(),
   ogImage: z.string().optional(),


### PR DESCRIPTION
This commit adds support for an optional subtitle field in blog post frontmatter. The subtitle feature works as follows:

- In blog listings: subtitle is displayed below the title
- In series navigation: subtitle is shown instead of title when available
- In article pages: subtitle is displayed below the title
- In HTML head tags: uses "title - subtitle" format when subtitle exists

Changes:
- Add subtitle field to blog frontmatter schema (optional)
- Update Timeline component to display subtitle below title
- Update Article component to display subtitle below title
- Update series navigation to prefer subtitle over title
- Update series page to display subtitle below title
- Update metadata generation to include subtitle in page titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional subtitle functionality for blog posts. Subtitles now display consistently across article pages, series listings, post timelines, and navigation elements. The feature is fully backward compatible with existing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->