### PR TITLE
Fix OGP image display issue

### DIFF
--- a/src/app/blog/post/[slug]/opengraph-image.tsx
+++ b/src/app/blog/post/[slug]/opengraph-image.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/libs/og-image";
 import { getFrontmatter } from "@/libs/contents/markdown";
 import { Pages } from "@/libs/contents/blog";
+import { generateSlugParams } from "@/libs/contents/params";
 
 // 静的生成の設定
 export const dynamic = "force-static";
@@ -18,6 +19,11 @@ export const alt = "Blog Post OGP Image";
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+// 静的エクスポートに必要な関数（すべてのブログ記事のslugを返す）
+export async function generateStaticParams() {
+  return generateSlugParams("blog");
+}
 
 // ブログ記事のOGP画像を生成
 export default async function Image({ params }: Props) {

--- a/src/app/blog/post/[slug]/opengraph-image.tsx
+++ b/src/app/blog/post/[slug]/opengraph-image.tsx
@@ -35,18 +35,17 @@ export default async function Image({ params }: Props) {
     schema: Pages["blog"].frontmatter,
   });
 
+  // 日本語フォントデータの取得
+  const fontData = await loadJapaneseFont();
+
   if (!frontmatter) {
     // フロントマターが取得できない場合はデフォルト画像
-    const fontData = await loadJapaneseFont();
     return generateOgImage({
       title: "Blog Post",
       category: "Blog",
       fontData,
     });
   }
-
-  // 日本語フォントデータの取得
-  const fontData = await loadJapaneseFont();
 
   // ブログ記事用のOGP画像を生成して返す
   return generateOgImage({

--- a/src/app/blog/post/[slug]/opengraph-image.tsx
+++ b/src/app/blog/post/[slug]/opengraph-image.tsx
@@ -1,0 +1,65 @@
+import {
+  OG_IMAGE_SIZE,
+  OG_CONTENT_TYPE,
+  loadJapaneseFont,
+  generateOgImage,
+} from "@/libs/og-image";
+import { getFrontmatter } from "@/libs/contents/markdown";
+import { Pages } from "@/libs/contents/blog";
+import { generateSlugParams } from "@/libs/contents/params";
+
+// 静的生成の設定
+export const dynamic = "force-static";
+
+// メタデータ
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Blog Post OGP Image";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+// 静的パラメータの生成（すべてのブログ記事のslugを返す）
+export async function generateImageMetadata() {
+  const slugParams = await generateSlugParams("blog");
+  return slugParams.map((param) => ({
+    id: param.slug,
+  }));
+}
+
+// ブログ記事のOGP画像を生成
+export default async function Image({ params }: Props) {
+  const { slug } = await params;
+
+  // フロントマターを取得
+  const frontmatter = await getFrontmatter({
+    paths: ["blog", slug],
+    schema: Pages["blog"].frontmatter,
+  });
+
+  if (!frontmatter) {
+    // フロントマターが取得できない場合はデフォルト画像
+    const fontData = await loadJapaneseFont();
+    return generateOgImage({
+      title: "Blog Post",
+      category: "Blog",
+      fontData,
+    });
+  }
+
+  // 日本語フォントデータの取得
+  const fontData = await loadJapaneseFont();
+
+  // ブログ記事用のOGP画像を生成して返す
+  return generateOgImage({
+    title: frontmatter.title,
+    category: frontmatter.category,
+    date: new Date(frontmatter.date).toLocaleDateString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }),
+    fontData,
+  });
+}

--- a/src/app/blog/post/[slug]/opengraph-image.tsx
+++ b/src/app/blog/post/[slug]/opengraph-image.tsx
@@ -6,7 +6,6 @@ import {
 } from "@/libs/og-image";
 import { getFrontmatter } from "@/libs/contents/markdown";
 import { Pages } from "@/libs/contents/blog";
-import { generateSlugParams } from "@/libs/contents/params";
 
 // 静的生成の設定
 export const dynamic = "force-static";
@@ -19,14 +18,6 @@ export const alt = "Blog Post OGP Image";
 type Props = {
   params: Promise<{ slug: string }>;
 };
-
-// 静的パラメータの生成（すべてのブログ記事のslugを返す）
-export async function generateImageMetadata() {
-  const slugParams = await generateSlugParams("blog");
-  return slugParams.map((param) => ({
-    id: param.slug,
-  }));
-}
 
 // ブログ記事のOGP画像を生成
 export default async function Image({ params }: Props) {


### PR DESCRIPTION
ブログ記事のOGP画像が表示されない問題を修正しました。

- src/app/blog/post/[slug]/opengraph-image.tsxを新規作成
- 各ブログ記事に対して動的にOGP画像を生成
- generateImageMetadataを実装し、静的生成に対応
- 記事のタイトル、カテゴリ、日付を含むOGP画像を生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blog posts now produce statically generated Open Graph preview images for social sharing.
  * Preview images show the post title, category, and publication date formatted for Japanese locales.
  * Japanese typography is embedded for consistent rendering; a default fallback image is used when post metadata is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->