### PR TITLE
Fix npm run command syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "copy:blog:css": "cpy 'src/contents/blog/**/*.css' 'public/assets/blog'",
     "start": "next start",
     "tsm": "typed-scss-modules src --watch --implementation sass --nameFormat none --exportType default --aliasPrefixes.@ src/",
+    "format": "biome format --write",
+    "format:check": "biome format",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "storybook": "npm run clean && storybook dev -p 6006",


### PR DESCRIPTION
Add `npm run format` and `npm run format:check` commands using Biome formatter.
- format: Applies formatting to all files
- format:check: Checks formatting without modifying files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added `format` script for code formatting
  * Added `format:check` script for formatting validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->