### PR TITLE
feat: ブログのToCをABUI Crux UI clerk variantに変更

### DIFF
--- a/src/foundation/pages/blog/post/ui/toc.tsx
+++ b/src/foundation/pages/blog/post/ui/toc.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-
-import { cn } from "@/shared/lib/utils";
+import { TOCProvider, TOCScrollArea, ClerkTOCItems } from "@/shared/ui/toc-crux";
 import { I18nText } from "@/shared/ui/i18n-text";
 import type { TocHeading } from "@/shared/lib/mdx";
 import type { Locale } from "@/shared/lib/routing";
@@ -13,81 +11,26 @@ type TocProps = {
 };
 
 export function Toc({ headings, locale }: TocProps) {
-  const [activeId, setActiveId] = useState<string | null>(null);
-
-  const headingIds = useMemo(() => headings.map((heading) => heading.id), [headings]);
-
-  useEffect(() => {
-    if (headingIds.length === 0) {
-      return;
-    }
-
-    const elements = headingIds
-      .map((id) => document.getElementById(id))
-      .filter((element): element is HTMLElement => Boolean(element));
-
-    if (elements.length === 0) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries.filter((entry) => entry.isIntersecting);
-        if (visible.length === 0) {
-          return;
-        }
-        visible.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        const target = visible[0]?.target as HTMLElement | undefined;
-        if (target?.id) {
-          setActiveId(target.id);
-        }
-      },
-      {
-        rootMargin: "0px 0px -70% 0px",
-        threshold: [0.1, 1],
-      },
-    );
-
-    elements.forEach((element) => observer.observe(element));
-
-    return () => {
-      elements.forEach((element) => observer.unobserve(element));
-      observer.disconnect();
-    };
-  }, [headingIds]);
-
-  useEffect(() => {
-    if (!activeId && headings.length > 0) {
-      setActiveId(headings[0]?.id ?? null);
-    }
-  }, [activeId, headings]);
-
   if (headings.length === 0) {
     return null;
   }
 
+  const toc = headings.map((h) => ({
+    title: h.text,
+    url: `#${h.id}`,
+    depth: h.level,
+  }));
+
   return (
-    <aside className="sticky top-28 max-h-[calc(100vh-8rem)] overflow-auto pr-2 text-sm">
-      <div className="mb-4 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-        <I18nText locale={locale} ja="目次" en="Contents" />
-      </div>
-      <ol className="space-y-2 text-muted-foreground">
-        {headings.map((heading) => (
-          <li key={heading.id} className={heading.level === 3 ? "pl-5" : ""}>
-            <a
-              href={`#${heading.id}`}
-              className={cn(
-                "group flex items-start gap-2 border-l border-transparent py-1 pl-2 text-sm transition-colors hover:text-foreground",
-                activeId === heading.id
-                  ? "border-foreground/70 text-foreground"
-                  : "border-transparent text-muted-foreground",
-              )}
-            >
-              <span className="min-w-0 flex-1">{heading.text}</span>
-            </a>
-          </li>
-        ))}
-      </ol>
-    </aside>
+    <TOCProvider toc={toc}>
+      <aside className="sticky top-28 flex max-h-[calc(100vh-8rem)] flex-col gap-3 overflow-hidden text-sm">
+        <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+          <I18nText locale={locale} ja="目次" en="Contents" />
+        </p>
+        <TOCScrollArea className="min-h-0 flex-1">
+          <ClerkTOCItems />
+        </TOCScrollArea>
+      </aside>
+    </TOCProvider>
   );
 }

--- a/src/foundation/shared/ui/toc-crux.tsx
+++ b/src/foundation/shared/ui/toc-crux.tsx
@@ -1,0 +1,499 @@
+"use client"
+
+import * as React from "react"
+import {
+  createContext,
+  useContext,
+  useRef,
+  useState,
+  useEffect,
+  useMemo,
+  useLayoutEffect,
+  type ReactNode,
+  type RefObject,
+  type ComponentProps,
+  type HTMLAttributes,
+} from "react"
+import { cn } from "@/shared/lib/utils"
+
+export interface TOCItemType {
+  title: ReactNode
+  url: string
+  depth: number
+}
+
+export type TableOfContents = TOCItemType[]
+
+const ActiveAnchorContext = createContext<string[]>([])
+const ScrollContext = createContext<RefObject<HTMLElement | null>>({ current: null })
+const TOCContext = createContext<TOCItemType[]>([])
+
+export function useActiveAnchors(): string[] {
+  return useContext(ActiveAnchorContext)
+}
+
+export function useActiveAnchor(): string | undefined {
+  return useContext(ActiveAnchorContext)[0]
+}
+
+export function useTOCItems(): TOCItemType[] {
+  return useContext(TOCContext)
+}
+
+function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> {
+  return value => {
+    refs.forEach(ref => {
+      if (typeof ref === "function") {
+        ref(value)
+      } else if (ref != null) {
+        ;(ref as React.MutableRefObject<T | null>).current = value
+      }
+    })
+  }
+}
+
+function useAnchorObserver(watch: string[], single: boolean): string[] {
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const [activeAnchor, setActiveAnchor] = useState<string[]>([])
+  const stateRef = useRef<{ visible: Set<string> } | null>(null)
+
+  const onChange = React.useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      stateRef.current ??= { visible: new Set() }
+      const state = stateRef.current
+
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          state.visible.add(entry.target.id)
+        } else {
+          state.visible.delete(entry.target.id)
+        }
+      }
+
+      if (state.visible.size === 0) {
+        const viewTop = entries[0]?.rootBounds?.top ?? 0
+        let fallback: Element | undefined
+        let min = -1
+
+        for (const id of watch) {
+          const element = document.getElementById(id)
+          if (!element) continue
+
+          const d = Math.abs(viewTop - element.getBoundingClientRect().top)
+          if (min === -1 || d < min) {
+            fallback = element
+            min = d
+          }
+        }
+
+        setActiveAnchor(fallback ? [fallback.id] : [])
+      } else {
+        const items = watch.filter(item => state.visible.has(item))
+        setActiveAnchor(single ? items.slice(0, 1) : items)
+      }
+    },
+    [watch, single],
+  )
+
+  useEffect(() => {
+    if (observerRef.current) return
+    observerRef.current = new IntersectionObserver(onChange, {
+      rootMargin: "0px",
+      threshold: 0.98,
+    })
+
+    return () => {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+    }
+  }, [onChange])
+
+  useEffect(() => {
+    const observer = observerRef.current
+    if (!observer) return
+    const elements = watch.flatMap(heading => document.getElementById(heading) ?? [])
+
+    for (const element of elements) observer.observe(element)
+    return () => {
+      for (const element of elements) observer.unobserve(element)
+    }
+  }, [watch])
+
+  return activeAnchor
+}
+
+export interface TOCProviderProps {
+  toc: TableOfContents
+  single?: boolean
+  children?: ReactNode
+}
+
+export function TOCProvider({ toc, single = false, children }: TOCProviderProps) {
+  const headings = useMemo(() => {
+    return toc.map(item => item.url.split("#")[1])
+  }, [toc])
+
+  const activeAnchors = useAnchorObserver(headings as string[], single)
+
+  return (
+    <TOCContext.Provider value={toc}>
+      <ActiveAnchorContext.Provider value={activeAnchors}>{children}</ActiveAnchorContext.Provider>
+    </TOCContext.Provider>
+  )
+}
+
+export function TOCScrollArea({ ref, className, ...props }: ComponentProps<"div">) {
+  const viewRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <div
+      ref={mergeRefs(viewRef, ref)}
+      className={cn(
+        "relative min-h-0 text-sm ms-px overflow-auto [scrollbar-width:none] [mask-image:linear-gradient(to_bottom,transparent,white_16px,white_calc(100%-16px),transparent)] py-3",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollContext.Provider value={viewRef}>{props.children}</ScrollContext.Provider>
+    </div>
+  )
+}
+
+type TocThumbValues = [top: number, height: number]
+
+interface TocThumbProps extends HTMLAttributes<HTMLDivElement> {
+  containerRef: RefObject<HTMLElement | null>
+}
+
+function calcThumb(container: HTMLElement, active: string[]): TocThumbValues {
+  if (active.length === 0 || container.clientHeight === 0) {
+    return [0, 0]
+  }
+
+  let upper = Number.MAX_VALUE
+  let lower = 0
+
+  for (const item of active) {
+    const element = container.querySelector<HTMLElement>(`a[href="#${item}"]`)
+    if (!element) continue
+
+    const styles = getComputedStyle(element)
+    upper = Math.min(upper, element.offsetTop + parseFloat(styles.paddingTop))
+    lower = Math.max(lower, element.offsetTop + element.clientHeight - parseFloat(styles.paddingBottom))
+  }
+
+  return [upper, lower - upper]
+}
+
+function updateThumb(element: HTMLElement, info: TocThumbValues): void {
+  element.style.setProperty("--toc-top", `${info[0]}px`)
+  element.style.setProperty("--toc-height", `${info[1]}px`)
+}
+
+function TocThumb({ containerRef, ...props }: TocThumbProps) {
+  const thumbRef = useRef<HTMLDivElement>(null)
+  const active = useActiveAnchors()
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const container = containerRef.current
+
+    const onUpdate = () => {
+      if (!thumbRef.current) return
+      updateThumb(thumbRef.current, calcThumb(container, active))
+    }
+
+    const observer = new ResizeObserver(onUpdate)
+    observer.observe(container)
+    onUpdate()
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [containerRef, active])
+
+  if (containerRef.current && thumbRef.current) {
+    updateThumb(thumbRef.current, calcThumb(containerRef.current, active))
+  }
+
+  return <div ref={thumbRef} role="none" {...props} />
+}
+
+export interface TOCItemProps extends Omit<ComponentProps<"a">, "href"> {
+  href: string
+  onActiveChange?: (v: boolean) => void
+}
+
+export function TOCItem({ ref, onActiveChange, ...props }: TOCItemProps) {
+  const containerRef = useContext(ScrollContext)
+  const anchorRef = useRef<HTMLAnchorElement>(null)
+  const activeAnchors = useActiveAnchors()
+  const activeOrder = activeAnchors.indexOf(props.href.slice(1))
+  const isActive = activeOrder !== -1
+  const shouldScroll = activeOrder === 0
+
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current
+    const container = containerRef.current
+
+    if (!container || !anchor || !shouldScroll || !anchor.isConnected) {
+      return
+    }
+
+    const containerRect = container.getBoundingClientRect()
+    const anchorRect = anchor.getBoundingClientRect()
+
+    const isAbove = anchorRect.top < containerRect.top
+    const isBelow = anchorRect.bottom > containerRect.bottom
+
+    if (isAbove || isBelow) {
+      const anchorCenter = anchor.offsetTop - container.offsetTop + anchor.offsetHeight / 2
+      const containerCenter = container.clientHeight / 2
+      const scrollTop = anchorCenter - containerCenter
+
+      container.scrollTo({
+        top: Math.max(0, scrollTop),
+        behavior: "smooth",
+      })
+    }
+  }, [containerRef, shouldScroll])
+
+  useEffect(() => {
+    onActiveChange?.(isActive)
+  }, [isActive, onActiveChange])
+
+  return (
+    <a ref={mergeRefs(anchorRef, ref)} data-active={isActive} {...props}>
+      {props.children}
+    </a>
+  )
+}
+
+export interface TOCItemsProps extends ComponentProps<"div"> {
+  emptyText?: string
+}
+
+export function TOCItems({ ref, className, emptyText = "No Headings", ...props }: TOCItemsProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const items = useTOCItems()
+
+  if (items.length === 0) {
+    return <div className="rounded-lg border bg-card p-3 text-xs text-muted-foreground">{emptyText}</div>
+  }
+
+  return (
+    <>
+      <TocThumb
+        containerRef={containerRef}
+        className="absolute top-[var(--toc-top)] h-[var(--toc-height)] w-px bg-primary transition-all"
+      />
+      <div
+        ref={mergeRefs(ref, containerRef)}
+        className={cn("flex flex-col border-s border-foreground/10", className)}
+        {...props}
+      >
+        {items.map(item => (
+          <SimpleTOCItem key={item.url} item={item} />
+        ))}
+      </div>
+    </>
+  )
+}
+
+function SimpleTOCItem({ item }: { item: TOCItemType }) {
+  return (
+    <TOCItem
+      href={item.url}
+      className={cn(
+        "prose py-1.5 text-sm text-muted-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-primary hover:text-accent-foreground",
+        item.depth <= 2 && "ps-3",
+        item.depth === 3 && "ps-6",
+        item.depth >= 4 && "ps-8",
+      )}
+    >
+      {item.title}
+    </TOCItem>
+  )
+}
+
+function getItemOffset(depth: number): number {
+  if (depth <= 2) return 14
+  if (depth === 3) return 26
+  return 36
+}
+
+function getLineOffset(depth: number): number {
+  return depth >= 3 ? 10 : 0
+}
+
+export interface ClerkTOCItemsProps extends ComponentProps<"div"> {
+  emptyText?: string
+}
+
+export function ClerkTOCItems({ ref, className, emptyText = "No Headings", ...props }: ClerkTOCItemsProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const items = useTOCItems()
+
+  const [svg, setSvg] = useState<{
+    path: string
+    width: number
+    height: number
+  }>()
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const container = containerRef.current
+
+    function onResize(): void {
+      if (container.clientHeight === 0) return
+      let w = 0
+      let h = 0
+      const d: string[] = []
+
+      for (let i = 0; i < items.length; i++) {
+        const element: HTMLElement | null = container.querySelector(`a[href="#${items[i]?.url.slice(1)}"]`)
+        if (!element) continue
+
+        const styles = getComputedStyle(element)
+        const offset = getLineOffset(items[i]?.depth ?? 2) + 1
+        const top = element.offsetTop + parseFloat(styles.paddingTop)
+        const bottom = element.offsetTop + element.clientHeight - parseFloat(styles.paddingBottom)
+
+        w = Math.max(offset, w)
+        h = Math.max(h, bottom)
+
+        d.push(`${i === 0 ? "M" : "L"}${offset} ${top}`)
+        d.push(`L${offset} ${bottom}`)
+      }
+
+      setSvg({
+        path: d.join(" "),
+        width: w + 1,
+        height: h,
+      })
+    }
+
+    const observer = new ResizeObserver(onResize)
+    onResize()
+
+    observer.observe(container)
+    return () => {
+      observer.disconnect()
+    }
+  }, [items])
+
+  if (items.length === 0) {
+    return <div className="rounded-lg border bg-card p-3 text-xs text-muted-foreground">{emptyText}</div>
+  }
+
+  return (
+    <>
+      {svg ? (
+        <div
+          className="absolute start-0 top-0 rtl:-scale-x-100"
+          style={{
+            width: svg.width,
+            height: svg.height,
+            maskImage: `url("data:image/svg+xml,${encodeURIComponent(
+              `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svg.width} ${svg.height}"><path d="${svg.path}" stroke="black" stroke-width="1" fill="none" /></svg>`,
+            )}")`,
+          }}
+        >
+          <TocThumb
+            containerRef={containerRef}
+            className="mt-[var(--toc-top)] h-[var(--toc-height)] bg-primary transition-all"
+          />
+        </div>
+      ) : null}
+      <div ref={mergeRefs(containerRef, ref)} className={cn("flex flex-col", className)} {...props}>
+        {items.map((item, i) => {
+          const prev = items[i - 1]
+          const next = items[i + 1]
+          return (
+            <ClerkTOCItemElement
+              key={item.url}
+              item={item}
+              {...(prev ? { upper: prev.depth } : {})}
+              {...(next ? { lower: next.depth } : {})}
+            />
+          )
+        })}
+      </div>
+    </>
+  )
+}
+
+function ClerkTOCItemElement({
+  item,
+  upper = item.depth,
+  lower = item.depth,
+}: {
+  item: TOCItemType
+  upper?: number
+  lower?: number
+}) {
+  const offset = getLineOffset(item.depth)
+  const upperOffset = getLineOffset(upper)
+  const lowerOffset = getLineOffset(lower)
+
+  return (
+    <TOCItem
+      href={item.url}
+      style={{
+        paddingInlineStart: getItemOffset(item.depth),
+      }}
+      className="prose relative py-1.5 text-sm text-muted-foreground hover:text-accent-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-primary"
+    >
+      {offset !== upperOffset ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 16 16"
+          className="absolute -top-1.5 start-0 size-4 rtl:-scale-x-100"
+        >
+          <line x1={upperOffset} y1="0" x2={offset} y2="12" className="stroke-foreground/10" strokeWidth="1" />
+        </svg>
+      ) : null}
+      <div
+        className={cn(
+          "absolute inset-y-0 w-px bg-foreground/10",
+          offset !== upperOffset && "top-1.5",
+          offset !== lowerOffset && "bottom-1.5",
+        )}
+        style={{
+          insetInlineStart: offset,
+        }}
+      />
+      {item.title}
+    </TOCItem>
+  )
+}
+
+export interface PageTOCProps extends ComponentProps<"div"> {
+  children?: ReactNode
+}
+
+export function PageTOC({ className, children, ...props }: PageTOCProps) {
+  return (
+    <div className={cn("flex flex-col gap-3", className)} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export interface PageTOCItemsProps extends ComponentProps<"div"> {
+  variant?: "default" | "clerk"
+  emptyText?: string
+}
+
+export function PageTOCItems({ variant = "default", emptyText, ...props }: PageTOCItemsProps) {
+  const emptyTextProp = emptyText !== undefined ? { emptyText } : {}
+  return (
+    <TOCScrollArea>
+      {variant === "clerk" ? (
+        <ClerkTOCItems {...emptyTextProp} {...props} />
+      ) : (
+        <TOCItems {...emptyTextProp} {...props} />
+      )}
+    </TOCScrollArea>
+  )
+}


### PR DESCRIPTION
## Summary

- ABUI Crux UIの [`toc`](https://crux-ui.vercel.app/r/toc.json) コンポーネントをローカルに追加 (`shared/ui/toc-crux.tsx`)
- ブログ記事ページのToCを clerk variant に切り替え
- 見出し階層に追従するSVGライン・アクティブセクションのマスクハイライトが有効

## Changes

- `src/foundation/shared/ui/toc-crux.tsx` (新規): ABUI Crux UI ToCコンポーネント一式
  - `TOCProvider`, `TOCScrollArea`, `ClerkTOCItems`, `TOCItems`, `TOCItem`, `PageTOC`, `PageTOCItems` をエクスポート
  - `@/lib/utils` → `@/shared/lib/utils` にパスを適合
  - `exactOptionalPropertyTypes: true` に対応した型修正
- `src/foundation/pages/blog/post/ui/toc.tsx` (更新): 手書きIntersectionObserverを削除しClerk variantを使用

## Test plan

- [ ] ブログ記事ページ (`/blog/post/...`) でToCが右サイドバーに表示される
- [ ] スクロールに応じてアクティブな見出しがハイライトされる
- [ ] h2/h3の階層でSVGラインが正しく描画される
- [ ] TypeScriptエラーなし (`tsc --noEmit`)
- [ ] ビルド成功 (`next build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Blog post table of contents component was refactored to use a centralized system for improved maintainability
  * New shared table-of-contents infrastructure introduced to enable consistent TOC functionality across pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuzumiyaAoba/SuzumiyaAoba.github.io/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->