### PR TITLE
fix: ToCのタイトルが複数行になった際の行間を狭める

### DIFF
--- a/src/foundation/shared/ui/toc-crux.tsx
+++ b/src/foundation/shared/ui/toc-crux.tsx
@@ -305,7 +305,7 @@ function SimpleTOCItem({ item }: { item: TOCItemType }) {
     <TOCItem
       href={item.url}
       className={cn(
-        "prose py-1.5 text-sm text-muted-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-primary hover:text-accent-foreground",
+        "prose leading-snug py-1.5 text-sm text-muted-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-primary hover:text-accent-foreground",
         item.depth <= 2 && "ps-3",
         item.depth === 3 && "ps-6",
         item.depth >= 4 && "ps-8",
@@ -442,7 +442,7 @@ function ClerkTOCItemElement({
       style={{
         paddingInlineStart: getItemOffset(item.depth),
       }}
-      className="prose relative py-1.5 text-sm text-muted-foreground hover:text-accent-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-primary"
+      className="prose leading-snug relative py-1.5 text-sm text-muted-foreground hover:text-accent-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-primary"
     >
       {offset !== upperOffset ? (
         <svg


### PR DESCRIPTION
## Summary

- `SimpleTOCItem` と `ClerkTOCItemElement` の両方に `leading-snug` を追加
- `prose` クラスは `line-height: 1.75` を設定しており、タイトルが複数行になった際に行間が広すぎる問題を修正
- `leading-snug`（`line-height: 1.375`）で上書きすることで行間を適切に狭める

## Test plan

- [ ] ToC に長いタイトル（複数行になるもの）が含まれるページを確認
- [ ] default variant (`TOCItems`) と clerk variant (`ClerkTOCItems`) の両方を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table of contents rendering with enhanced text wrapping behavior and refined vertical spacing to provide better readability and visual presentation of TOC items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuzumiyaAoba/SuzumiyaAoba.github.io/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->